### PR TITLE
feat: introduce vibrant palette and theme extension

### DIFF
--- a/lib/components/modern_overview_card.dart
+++ b/lib/components/modern_overview_card.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../theme/app_theme.dart';
+
+class ModernOverviewCard extends StatelessWidget {
+  const ModernOverviewCard({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.trailing,
+    this.icon,
+  });
+
+  final String title;
+  final String subtitle;
+  final String trailing;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final palette = theme.extension<AppPalette>() ?? const AppPalette.light();
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 220),
+      curve: Curves.easeOutCubic,
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [palette.gradientStart, palette.gradientEnd],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(24),
+        boxShadow: [
+          BoxShadow(
+            color: palette.badgeBackground.withOpacity(0.18),
+            blurRadius: 26,
+            offset: const Offset(0, 18),
+          ),
+        ],
+        border: Border.all(color: palette.neutralContainer.withOpacity(0.6)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (icon != null)
+            Container(
+              height: 48,
+              width: 48,
+              decoration: BoxDecoration(
+                color: palette.neutralContainer.withOpacity(0.6),
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Icon(
+                icon,
+                color: colorScheme.primary,
+              ),
+            ),
+          if (icon != null) const SizedBox(width: 20),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: -0.1,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  subtitle,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(18),
+              gradient: LinearGradient(
+                colors: [
+                  palette.badgeBackground,
+                  colorScheme.primary,
+                ],
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: palette.badgeBackground.withOpacity(0.28),
+                  blurRadius: 20,
+                  offset: const Offset(0, 12),
+                ),
+              ],
+            ),
+            child: Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
+              child: Text(
+                trailing,
+                style: GoogleFonts.inter(
+                  fontWeight: FontWeight.w600,
+                  color: palette.badgeForeground,
+                  fontSize: 15,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/flutter_flow/flutter_flow_theme.dart
+++ b/lib/flutter_flow/flutter_flow_theme.dart
@@ -142,22 +142,22 @@ class LightModeTheme extends FlutterFlowTheme {
   @Deprecated('Use tertiary instead')
   Color get tertiaryColor => tertiary;
 
-  late Color primary = const Color(0xFF4A7CBA);
-  late Color secondary = const Color(0xFFCB5F6D);
-  late Color tertiary = const Color(0xFFF8D065);
-  late Color alternate = const Color(0xFFAAAAAA);
-  late Color primaryText = const Color(0xFF000000);
-  late Color secondaryText = const Color(0xFF6E7C8C);
-  late Color primaryBackground = const Color(0xFFF8F8F8);
+  late Color primary = const Color(0xFF0EA5E9);
+  late Color secondary = const Color(0xFF6366F1);
+  late Color tertiary = const Color(0xFFF97316);
+  late Color alternate = const Color(0xFFE2E8F5);
+  late Color primaryText = const Color(0xFF0F172A);
+  late Color secondaryText = const Color(0xFF475569);
+  late Color primaryBackground = const Color(0xFFF6F9FC);
   late Color secondaryBackground = const Color(0xFFFFFFFF);
-  late Color accent1 = const Color(0xFFF8D065);
-  late Color accent2 = const Color(0xFFCB5F6D);
-  late Color accent3 = const Color(0xFF82D0AB);
-  late Color accent4 = const Color(0xFF4A7CBA);
-  late Color success = const Color(0xFF82D0AB);
-  late Color warning = const Color(0xFFF8D065);
-  late Color error = const Color(0xFFCB5F6D);
-  late Color info = const Color(0xFF4A7CBA);
+  late Color accent1 = const Color(0xFFBFE6FB);
+  late Color accent2 = const Color(0xFFE4DEFF);
+  late Color accent3 = const Color(0xFFFFE2CB);
+  late Color accent4 = const Color(0xFF1E293B);
+  late Color success = const Color(0xFF22C55E);
+  late Color warning = const Color(0xFFFACC15);
+  late Color error = const Color(0xFFEF4444);
+  late Color info = const Color(0xFF0EA5E9);
 }
 
 abstract class Typography {
@@ -213,110 +213,114 @@ class ThemeTypography extends Typography {
 
   final FlutterFlowTheme theme;
 
-  String get displayLargeFamily => 'Noto Sans JP';
+  String get displayLargeFamily => 'Inter';
   bool get displayLargeIsCustom => false;
-  TextStyle get displayLarge => GoogleFonts.notoSansJp(
+  TextStyle get displayLarge => GoogleFonts.inter(
         color: theme.primaryText,
-        fontWeight: FontWeight.normal,
-        fontSize: 64.0,
+        fontWeight: FontWeight.w600,
+        fontSize: 56.0,
+        letterSpacing: -0.5,
       );
-  String get displayMediumFamily => 'Noto Sans JP';
+  String get displayMediumFamily => 'Inter';
   bool get displayMediumIsCustom => false;
-  TextStyle get displayMedium => GoogleFonts.notoSansJp(
+  TextStyle get displayMedium => GoogleFonts.inter(
         color: theme.primaryText,
-        fontWeight: FontWeight.normal,
+        fontWeight: FontWeight.w600,
         fontSize: 44.0,
       );
-  String get displaySmallFamily => 'Noto Sans JP';
+  String get displaySmallFamily => 'Inter';
   bool get displaySmallIsCustom => false;
-  TextStyle get displaySmall => GoogleFonts.notoSansJp(
+  TextStyle get displaySmall => GoogleFonts.inter(
         color: theme.primaryText,
         fontWeight: FontWeight.w600,
         fontSize: 36.0,
       );
-  String get headlineLargeFamily => 'Noto Sans JP';
+  String get headlineLargeFamily => 'Inter';
   bool get headlineLargeIsCustom => false;
-  TextStyle get headlineLarge => GoogleFonts.notoSansJp(
+  TextStyle get headlineLarge => GoogleFonts.inter(
         color: theme.primaryText,
         fontWeight: FontWeight.w600,
-        fontSize: 32.0,
+        fontSize: 30.0,
       );
-  String get headlineMediumFamily => 'Noto Sans JP';
+  String get headlineMediumFamily => 'Inter';
   bool get headlineMediumIsCustom => false;
-  TextStyle get headlineMedium => GoogleFonts.notoSansJp(
-        color: theme.primaryText,
-        fontWeight: FontWeight.normal,
-        fontSize: 24.0,
-      );
-  String get headlineSmallFamily => 'Noto Sans JP';
-  bool get headlineSmallIsCustom => false;
-  TextStyle get headlineSmall => GoogleFonts.notoSansJp(
+  TextStyle get headlineMedium => GoogleFonts.inter(
         color: theme.primaryText,
         fontWeight: FontWeight.w500,
-        fontSize: 24.0,
+        fontSize: 26.0,
       );
-  String get titleLargeFamily => 'Noto Sans JP';
-  bool get titleLargeIsCustom => false;
-  TextStyle get titleLarge => GoogleFonts.notoSansJp(
+  String get headlineSmallFamily => 'Inter';
+  bool get headlineSmallIsCustom => false;
+  TextStyle get headlineSmall => GoogleFonts.inter(
         color: theme.primaryText,
         fontWeight: FontWeight.w500,
         fontSize: 22.0,
       );
-  String get titleMediumFamily => 'Noto Sans JP';
-  bool get titleMediumIsCustom => false;
-  TextStyle get titleMedium => GoogleFonts.notoSansJp(
-        color: theme.primary,
-        fontWeight: FontWeight.normal,
+  String get titleLargeFamily => 'Inter';
+  bool get titleLargeIsCustom => false;
+  TextStyle get titleLarge => GoogleFonts.inter(
+        color: theme.primaryText,
+        fontWeight: FontWeight.w600,
         fontSize: 20.0,
       );
-  String get titleSmallFamily => 'Noto Sans JP';
+  String get titleMediumFamily => 'Inter';
+  bool get titleMediumIsCustom => false;
+  TextStyle get titleMedium => GoogleFonts.inter(
+        color: theme.secondary,
+        fontWeight: FontWeight.w500,
+        fontSize: 18.0,
+      );
+  String get titleSmallFamily => 'Inter';
   bool get titleSmallIsCustom => false;
-  TextStyle get titleSmall => GoogleFonts.notoSansJp(
+  TextStyle get titleSmall => GoogleFonts.inter(
         color: theme.secondaryText,
         fontWeight: FontWeight.w500,
         fontSize: 16.0,
       );
-  String get labelLargeFamily => 'Noto Sans JP';
+  String get labelLargeFamily => 'Inter';
   bool get labelLargeIsCustom => false;
-  TextStyle get labelLarge => GoogleFonts.notoSansJp(
-        color: theme.secondaryText,
-        fontWeight: FontWeight.normal,
-        fontSize: 16.0,
+  TextStyle get labelLarge => GoogleFonts.inter(
+        color: theme.secondaryBackground,
+        fontWeight: FontWeight.w600,
+        fontSize: 15.0,
       );
-  String get labelMediumFamily => 'Noto Sans JP';
+  String get labelMediumFamily => 'Inter';
   bool get labelMediumIsCustom => false;
-  TextStyle get labelMedium => GoogleFonts.notoSansJp(
+  TextStyle get labelMedium => GoogleFonts.inter(
         color: theme.secondaryText,
-        fontWeight: FontWeight.normal,
-        fontSize: 17.0,
+        fontWeight: FontWeight.w500,
+        fontSize: 13.0,
       );
-  String get labelSmallFamily => 'Noto Sans JP';
+  String get labelSmallFamily => 'Inter';
   bool get labelSmallIsCustom => false;
-  TextStyle get labelSmall => GoogleFonts.notoSansJp(
+  TextStyle get labelSmall => GoogleFonts.inter(
         color: theme.secondaryText,
-        fontWeight: FontWeight.normal,
-        fontSize: 14.0,
-      );
-  String get bodyLargeFamily => 'Noto Sans JP';
-  bool get bodyLargeIsCustom => false;
-  TextStyle get bodyLarge => GoogleFonts.notoSansJp(
-        color: theme.primaryText,
-        fontWeight: FontWeight.normal,
-        fontSize: 16.0,
-      );
-  String get bodyMediumFamily => 'Noto Sans JP';
-  bool get bodyMediumIsCustom => false;
-  TextStyle get bodyMedium => GoogleFonts.notoSansJp(
-        color: theme.primaryText,
-        fontWeight: FontWeight.normal,
-        fontSize: 14.0,
-      );
-  String get bodySmallFamily => 'Noto Sans JP';
-  bool get bodySmallIsCustom => false;
-  TextStyle get bodySmall => GoogleFonts.notoSansJp(
-        color: theme.primaryText,
-        fontWeight: FontWeight.normal,
+        fontWeight: FontWeight.w500,
         fontSize: 12.0,
+      );
+  String get bodyLargeFamily => 'Inter';
+  bool get bodyLargeIsCustom => false;
+  TextStyle get bodyLarge => GoogleFonts.inter(
+        color: theme.primaryText,
+        fontWeight: FontWeight.w400,
+        fontSize: 16.0,
+        height: 1.6,
+      );
+  String get bodyMediumFamily => 'Inter';
+  bool get bodyMediumIsCustom => false;
+  TextStyle get bodyMedium => GoogleFonts.inter(
+        color: theme.primaryText,
+        fontWeight: FontWeight.w400,
+        fontSize: 14.0,
+        height: 1.6,
+      );
+  String get bodySmallFamily => 'Inter';
+  bool get bodySmallIsCustom => false;
+  TextStyle get bodySmall => GoogleFonts.inter(
+        color: theme.secondaryText,
+        fontWeight: FontWeight.w400,
+        fontSize: 12.0,
+        height: 1.5,
       );
 }
 
@@ -328,22 +332,22 @@ class DarkModeTheme extends FlutterFlowTheme {
   @Deprecated('Use tertiary instead')
   Color get tertiaryColor => tertiary;
 
-  late Color primary = const Color(0xFF3B5D8A);
-  late Color secondary = const Color(0xFFB74C5C);
-  late Color tertiary = const Color(0xFFE0C054);
-  late Color alternate = const Color(0xFF6FB6A2);
-  late Color primaryText = const Color(0xFFFFFFFF);
-  late Color secondaryText = const Color(0xFFB0B0B0);
-  late Color primaryBackground = const Color(0xFF2C2C2C);
-  late Color secondaryBackground = const Color(0xFF1A1A1A);
-  late Color accent1 = const Color(0xFFE0C054);
-  late Color accent2 = const Color(0xFFB74C5C);
-  late Color accent3 = const Color(0xFF6FB6A2);
-  late Color accent4 = const Color(0xFF3B5D8A);
-  late Color success = const Color(0xFF6FB6A2);
-  late Color warning = const Color(0xFFE0C054);
-  late Color error = const Color(0xFFB74C5C);
-  late Color info = const Color(0xFF3B5D8A);
+  late Color primary = const Color(0xFF38BDF8);
+  late Color secondary = const Color(0xFFADB2FF);
+  late Color tertiary = const Color(0xFFFFB677);
+  late Color alternate = const Color(0xFF1E293B);
+  late Color primaryText = const Color(0xFFF8FAFC);
+  late Color secondaryText = const Color(0xFFA8B1CF);
+  late Color primaryBackground = const Color(0xFF0B1120);
+  late Color secondaryBackground = const Color(0xFF141C2C);
+  late Color accent1 = const Color(0xFF13476D);
+  late Color accent2 = const Color(0xFF2B2464);
+  late Color accent3 = const Color(0xFF4A2A10);
+  late Color accent4 = const Color(0xFF94A3B8);
+  late Color success = const Color(0xFF4ADE80);
+  late Color warning = const Color(0xFFEAB308);
+  late Color error = const Color(0xFFF87171);
+  late Color info = const Color(0xFF38BDF8);
 }
 
 extension TextStyleHelper on TextStyle {

--- a/lib/flutter_flow/flutter_flow_widgets.dart
+++ b/lib/flutter_flow/flutter_flow_widgets.dart
@@ -85,10 +85,44 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final defaultTextStyle = widget.options.textStyle ??
+        theme.textTheme.labelLarge?.copyWith(
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.2,
+          color: colorScheme.onPrimary,
+        );
+    final resolvedTextStyle = widget.options.textStyle ?? defaultTextStyle;
+    final buttonColor = widget.options.color ?? colorScheme.primary;
+    final hoverColor = widget.options.hoverColor ??
+        buttonColor.withOpacity(colorScheme.brightness == Brightness.dark
+            ? 0.18
+            : 0.12);
+    final splashColor = widget.options.splashColor ??
+        buttonColor.withOpacity(colorScheme.brightness == Brightness.dark
+            ? 0.22
+            : 0.16);
+    final disabledColor = widget.options.disabledColor ??
+        colorScheme.outlineVariant.withOpacity(0.6);
+    final disabledTextColor = widget.options.disabledTextColor ??
+        colorScheme.onSurface.withOpacity(0.38);
+    final borderRadius = widget.options.borderRadius ??
+        BorderRadius.circular(16);
+    final padding = widget.options.padding ??
+        const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0);
+
+    final bool hideText = resolvedTextStyle?.fontSize == 0;
+    final String? textContent = hideText ? null : widget.text;
+
     Widget textWidget = loading
         ? SizedBox(
             width: widget.options.width == null
-                ? _getTextWidth(text, widget.options.textStyle, maxLines)
+                ? _getTextWidth(
+                    textContent,
+                    resolvedTextStyle,
+                    maxLines,
+                  )
                 : null,
             child: Center(
               child: SizedBox(
@@ -96,16 +130,17 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
                 height: 23,
                 child: CircularProgressIndicator(
                   valueColor: AlwaysStoppedAnimation<Color>(
-                    widget.options.textStyle?.color ?? Colors.white,
+                    resolvedTextStyle?.color ?? colorScheme.onPrimary,
                   ),
                 ),
               ),
             ),
           )
         : AutoSizeText(
-            text ?? '',
-            style:
-                text == null ? null : widget.options.textStyle?.withoutColor(),
+            textContent ?? '',
+            style: textContent == null
+                ? null
+                : resolvedTextStyle?.withoutColor(),
             textAlign: widget.options.textAlign,
             maxLines: maxLines,
             overflow: TextOverflow.ellipsis,
@@ -134,22 +169,19 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
         if (states.contains(WidgetState.hovered) &&
             widget.options.hoverBorderSide != null) {
           return RoundedRectangleBorder(
-            borderRadius:
-                widget.options.borderRadius ?? BorderRadius.circular(8),
+            borderRadius: borderRadius,
             side: widget.options.hoverBorderSide!,
           );
         }
         if (states.contains(WidgetState.focused) &&
             widget.options.focusBorderSide != null) {
           return RoundedRectangleBorder(
-            borderRadius: widget.options.focusBorderRadius ??
-                widget.options.borderRadius ??
-                BorderRadius.circular(8),
+            borderRadius: widget.options.focusBorderRadius ?? borderRadius,
             side: widget.options.focusBorderSide!,
           );
         }
         return RoundedRectangleBorder(
-          borderRadius: widget.options.borderRadius ?? BorderRadius.circular(8),
+          borderRadius: borderRadius,
           side: widget.options.borderSide ?? BorderSide.none,
         );
       }),
@@ -162,7 +194,13 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
             widget.options.hoverTextColor != null) {
           return widget.options.hoverTextColor;
         }
-        return widget.options.textStyle?.color ?? Colors.white;
+        if (states.contains(WidgetState.disabled)) {
+          return disabledTextColor;
+        }
+        return resolvedTextStyle?.color ??
+            (widget.options.color != null
+                ? resolvedTextStyle?.color
+                : colorScheme.onPrimary);
       }),
       backgroundColor: WidgetStateProperty.resolveWith<Color?>((states) {
         if (states.contains(WidgetState.disabled) &&
@@ -173,24 +211,31 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
             widget.options.hoverColor != null) {
           return widget.options.hoverColor;
         }
-        return widget.options.color;
+        if (states.contains(WidgetState.disabled)) {
+          return disabledColor;
+        }
+        return buttonColor;
       }),
       overlayColor: WidgetStateProperty.resolveWith<Color?>((states) {
         if (states.contains(WidgetState.pressed)) {
-          return widget.options.splashColor;
+          return splashColor;
         }
-        return widget.options.hoverColor == null ? null : Colors.transparent;
+        return widget.options.hoverColor == null ? hoverColor : Colors.transparent;
       }),
-      padding: WidgetStateProperty.all(
-        widget.options.padding ??
-            const EdgeInsets.symmetric(horizontal: 12.0, vertical: 4.0),
-      ),
+      padding: WidgetStateProperty.all(padding),
       elevation: WidgetStateProperty.resolveWith<double?>((states) {
         if (states.contains(WidgetState.hovered) &&
             widget.options.hoverElevation != null) {
           return widget.options.hoverElevation!;
         }
-        return widget.options.elevation ?? 2.0;
+        if (states.contains(WidgetState.hovered) ||
+            states.contains(WidgetState.focused)) {
+          return (widget.options.elevation ?? 4.0) + 2;
+        }
+        if (states.contains(WidgetState.disabled)) {
+          return 0;
+        }
+        return widget.options.elevation ?? 4.0;
       }),
       iconColor: WidgetStateProperty.resolveWith<Color?>((states) {
         if (states.contains(WidgetState.disabled) &&
@@ -201,8 +246,18 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
             widget.options.hoverTextColor != null) {
           return widget.options.hoverTextColor;
         }
-        return widget.options.iconColor;
+        if (states.contains(WidgetState.disabled)) {
+          return disabledTextColor;
+        }
+        return widget.options.iconColor ??
+            (widget.options.color != null
+                ? resolvedTextStyle?.color
+                : colorScheme.onPrimary);
       }),
+      shadowColor: WidgetStateProperty.all(
+        theme.shadowColor.withOpacity(0.25),
+      ),
+      animationDuration: const Duration(milliseconds: 200),
     );
 
     if ((widget.icon != null || widget.iconData != null) && !loading) {
@@ -210,10 +265,13 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
           FaIcon(
             widget.iconData!,
             size: widget.options.iconSize,
-            color: widget.options.iconColor,
+            color: widget.options.iconColor ??
+                (widget.options.color != null
+                    ? resolvedTextStyle?.color
+                    : colorScheme.onPrimary),
           );
 
-      if (text == null) {
+      if (textContent == null) {
         return Container(
           height: widget.options.height,
           width: widget.options.width,
@@ -221,8 +279,14 @@ class _FFButtonWidgetState extends State<FFButtonWidget> {
             border: Border.fromBorderSide(
               widget.options.borderSide ?? BorderSide.none,
             ),
-            borderRadius:
-                widget.options.borderRadius ?? BorderRadius.circular(8),
+            borderRadius: borderRadius,
+            boxShadow: [
+              BoxShadow(
+                color: theme.shadowColor.withOpacity(0.15),
+                blurRadius: 16,
+                offset: const Offset(0, 10),
+              ),
+            ],
           ),
           child: IconButton(
             splashRadius: 1.0,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import '/backend/supabase/supabase.dart';
 import '/flutter_flow/flutter_flow_theme.dart';
 import 'flutter_flow/flutter_flow_util.dart';
 import 'flutter_flow/internationalization.dart';
+import 'theme/app_theme.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -114,14 +115,8 @@ class _MyAppState extends State<MyApp> {
       supportedLocales: const [
         Locale('es'),
       ],
-      theme: ThemeData(
-        brightness: Brightness.light,
-        useMaterial3: false,
-      ),
-      darkTheme: ThemeData(
-        brightness: Brightness.dark,
-        useMaterial3: false,
-      ),
+      theme: AppTheme.lightTheme,
+      darkTheme: AppTheme.darkTheme,
       themeMode: _themeMode,
       routerConfig: _router,
     );

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,619 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTheme {
+  static const _lightPrimary = Color(0xFF0EA5E9);
+  static const _lightSecondary = Color(0xFF6366F1);
+  static const _lightTertiary = Color(0xFFF97316);
+  static const _lightQuaternary = Color(0xFF22C55E);
+  static const _lightSurface = Color(0xFFF6F9FC);
+  static const _lightSurfaceVariant = Color(0xFFFFFFFF);
+  static const _lightNeutral = Color(0xFFE2E8F5);
+  static const _lightGradientStart = Color(0xFFE0F2FE);
+  static const _lightGradientEnd = Color(0xFFEAE8FF);
+
+  static const _darkPrimary = Color(0xFF38BDF8);
+  static const _darkSecondary = Color(0xFFADB2FF);
+  static const _darkTertiary = Color(0xFFFFB677);
+  static const _darkQuaternary = Color(0xFF4ADE80);
+  static const _darkSurface = Color(0xFF0B1120);
+  static const _darkSurfaceVariant = Color(0xFF141C2C);
+  static const _darkNeutral = Color(0xFF1E293B);
+  static const _darkGradientStart = Color(0xFF10273A);
+  static const _darkGradientEnd = Color(0xFF1F1A3F);
+
+  static ThemeData get lightTheme {
+    final baseTextTheme = GoogleFonts.interTextTheme();
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.light,
+      extensions: const <ThemeExtension<dynamic>>[
+        AppPalette.light(),
+      ],
+      colorScheme: const ColorScheme(
+        brightness: Brightness.light,
+        primary: _lightPrimary,
+        onPrimary: Colors.white,
+        secondary: _lightSecondary,
+        onSecondary: Colors.white,
+        tertiary: _lightTertiary,
+        onTertiary: Colors.white,
+        error: Color(0xFFEF4444),
+        onError: Colors.white,
+        surface: _lightSurface,
+        onSurface: Color(0xFF1F2937),
+        primaryContainer: Color(0xFFBFE6FB),
+        onPrimaryContainer: Color(0xFF06283B),
+        secondaryContainer: Color(0xFFE4DEFF),
+        onSecondaryContainer: Color(0xFF23105F),
+        tertiaryContainer: Color(0xFFFFE2CB),
+        onTertiaryContainer: Color(0xFF4A1B00),
+        surfaceTint: _lightPrimary,
+        surfaceVariant: _lightSurfaceVariant,
+        onSurfaceVariant: Color(0xFF4B5563),
+        outline: Color(0xFFCBD5E1),
+        outlineVariant: Color(0xFFE2E8F0),
+        shadow: Color(0x1A0F172A),
+        scrim: Colors.black54,
+        inverseSurface: Color(0xFF111827),
+        onInverseSurface: Color(0xFFE5E7EB),
+        inversePrimary: _lightSecondary,
+      ),
+      scaffoldBackgroundColor: _lightSurface,
+      textTheme: baseTextTheme.copyWith(
+        displayLarge: baseTextTheme.displayLarge?.copyWith(
+          fontSize: 54,
+          fontWeight: FontWeight.w600,
+          letterSpacing: -0.5,
+          color: const Color(0xFF111827),
+        ),
+        displayMedium: baseTextTheme.displayMedium?.copyWith(
+          fontSize: 44,
+          fontWeight: FontWeight.w600,
+          color: const Color(0xFF111827),
+        ),
+        displaySmall: baseTextTheme.displaySmall?.copyWith(
+          fontSize: 36,
+          fontWeight: FontWeight.w600,
+          color: const Color(0xFF111827),
+        ),
+        headlineLarge: baseTextTheme.headlineLarge?.copyWith(
+          fontSize: 30,
+          fontWeight: FontWeight.w600,
+          color: const Color(0xFF1F2937),
+        ),
+        headlineMedium: baseTextTheme.headlineMedium?.copyWith(
+          fontSize: 26,
+          fontWeight: FontWeight.w500,
+          color: const Color(0xFF1F2937),
+        ),
+        headlineSmall: baseTextTheme.headlineSmall?.copyWith(
+          fontSize: 22,
+          fontWeight: FontWeight.w500,
+          color: const Color(0xFF1F2937),
+        ),
+        titleLarge: baseTextTheme.titleLarge?.copyWith(
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+          color: const Color(0xFF1F2937),
+        ),
+        titleMedium: baseTextTheme.titleMedium?.copyWith(
+          fontSize: 18,
+          fontWeight: FontWeight.w500,
+          color: const Color(0xFF334155),
+        ),
+        titleSmall: baseTextTheme.titleSmall?.copyWith(
+          fontSize: 16,
+          fontWeight: FontWeight.w500,
+          color: const Color(0xFF475569),
+        ),
+        bodyLarge: baseTextTheme.bodyLarge?.copyWith(
+          fontSize: 16,
+          height: 1.6,
+          color: const Color(0xFF1F2937),
+        ),
+        bodyMedium: baseTextTheme.bodyMedium?.copyWith(
+          fontSize: 14,
+          height: 1.6,
+          color: const Color(0xFF334155),
+        ),
+        bodySmall: baseTextTheme.bodySmall?.copyWith(
+          fontSize: 12,
+          height: 1.5,
+          color: const Color(0xFF64748B),
+        ),
+        labelLarge: baseTextTheme.labelLarge?.copyWith(
+          fontSize: 15,
+          fontWeight: FontWeight.w600,
+          color: Colors.white,
+        ),
+        labelMedium: baseTextTheme.labelMedium?.copyWith(
+          fontSize: 13,
+          fontWeight: FontWeight.w500,
+          color: const Color(0xFF475569),
+        ),
+        labelSmall: baseTextTheme.labelSmall?.copyWith(
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+          color: const Color(0xFF64748B),
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+          minimumSize: WidgetStateProperty.all(const Size.fromHeight(48)),
+          padding: WidgetStateProperty.all(
+            const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          ),
+          shape: WidgetStateProperty.all(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          ),
+          elevation: WidgetStateProperty.resolveWith<double>((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return 0;
+            }
+            if (states.contains(WidgetState.hovered) ||
+                states.contains(WidgetState.pressed)) {
+              return 8;
+            }
+            return 4;
+          }),
+          backgroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return _lightPrimary.withOpacity(0.26);
+            }
+            return _lightPrimary;
+          }),
+          foregroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return const Color(0xFF94A3B8);
+            }
+            return Colors.white;
+          }),
+          overlayColor: WidgetStateProperty.all(
+            const Color(0x140EA5E9),
+          ),
+          shadowColor: WidgetStateProperty.all(
+            _lightPrimary.withOpacity(0.26),
+          ),
+          animationDuration: const Duration(milliseconds: 200),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: ButtonStyle(
+          minimumSize: WidgetStateProperty.all(const Size.fromHeight(48)),
+          padding: WidgetStateProperty.all(
+            const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          ),
+          shape: WidgetStateProperty.all(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+          ),
+          side: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.hovered) ||
+                states.contains(WidgetState.pressed)) {
+              return const BorderSide(color: _lightSecondary, width: 2);
+            }
+            return BorderSide(color: _lightPrimary.withOpacity(0.26));
+          }),
+          foregroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return const Color(0xFF94A3B8);
+            }
+            return _lightSecondary;
+          }),
+          overlayColor: WidgetStateProperty.all(
+            const Color(0x146366F1),
+          ),
+          animationDuration: const Duration(milliseconds: 200),
+        ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: ButtonStyle(
+          padding: WidgetStateProperty.all(
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          ),
+          foregroundColor: WidgetStateProperty.all(_lightSecondary),
+          shape: WidgetStateProperty.all(
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          ),
+        ),
+      ),
+      cardTheme: CardTheme(
+        color: _lightSurfaceVariant,
+        shadowColor: _lightPrimary.withOpacity(0.12),
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        margin: const EdgeInsets.all(16),
+        elevation: 6,
+      ),
+      dialogTheme: DialogTheme(
+        backgroundColor: _lightSurfaceVariant,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+        titleTextStyle: baseTextTheme.titleLarge?.copyWith(
+          fontWeight: FontWeight.w700,
+          color: const Color(0xFF0F172A),
+        ),
+        contentTextStyle: baseTextTheme.bodyMedium,
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: const Color(0xFFFFFFFF),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: _lightNeutral),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: _lightNeutral),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: _lightPrimary, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: Color(0xFFEF4444)),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: Color(0xFFEF4444)),
+        ),
+        labelStyle: baseTextTheme.bodyMedium?.copyWith(
+          color: const Color(0xFF64748B),
+        ),
+        hintStyle: baseTextTheme.bodyMedium?.copyWith(
+          color: const Color(0xFF94A3B8),
+        ),
+      ),
+      listTileTheme: const ListTileThemeData(
+        contentPadding: EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+        tileColor: Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(16)),
+        ),
+      ),
+      dividerTheme: const DividerThemeData(
+        thickness: 1,
+        space: 32,
+        color: Color(0xFFE2E8F0),
+      ),
+      appBarTheme: AppBarTheme(
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        backgroundColor: _lightSurface,
+        surfaceTintColor: Colors.transparent,
+        foregroundColor: const Color(0xFF111827),
+        titleTextStyle: baseTextTheme.titleLarge?.copyWith(
+          fontWeight: FontWeight.w600,
+          color: const Color(0xFF111827),
+        ),
+        toolbarHeight: 72,
+        centerTitle: false,
+      ),
+      chipTheme: ChipThemeData(
+        backgroundColor: _lightNeutral,
+        selectedColor: _lightSecondary.withOpacity(0.16),
+        secondarySelectedColor: _lightSecondary,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        labelStyle: baseTextTheme.labelMedium!,
+        secondaryLabelStyle:
+            baseTextTheme.labelMedium!.copyWith(color: _lightSecondary),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        elevation: 0,
+        pressElevation: 0,
+      ),
+      floatingActionButtonTheme: const FloatingActionButtonThemeData(
+        backgroundColor: _lightTertiary,
+        foregroundColor: Color(0xFF1F2937),
+        shape: StadiumBorder(),
+      ),
+      bottomSheetTheme: BottomSheetThemeData(
+        backgroundColor: _lightSurfaceVariant,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        clipBehavior: Clip.antiAlias,
+        showDragHandle: true,
+      ),
+      navigationBarTheme: NavigationBarThemeData(
+        backgroundColor: _lightSurfaceVariant,
+        indicatorColor: _lightSecondary.withOpacity(0.18),
+        labelTextStyle: WidgetStateProperty.resolveWith(
+          (states) => baseTextTheme.labelMedium?.copyWith(
+            color: states.contains(WidgetState.selected)
+                ? _lightSecondary
+                : const Color(0xFF64748B),
+          ),
+        ),
+        iconTheme: WidgetStateProperty.resolveWith(
+          (states) => IconThemeData(
+            color: states.contains(WidgetState.selected)
+                ? _lightSecondary
+                : const Color(0xFF94A3B8),
+          ),
+        ),
+      ),
+      pageTransitionsTheme: const PageTransitionsTheme(builders: {
+        TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
+        TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+        TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
+        TargetPlatform.windows: FadeUpwardsPageTransitionsBuilder(),
+        TargetPlatform.linux: FadeUpwardsPageTransitionsBuilder(),
+      }),
+    );
+  }
+
+  static ThemeData get darkTheme {
+    final baseTextTheme = GoogleFonts.interTextTheme();
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.dark,
+      extensions: const <ThemeExtension<dynamic>>[
+        AppPalette.dark(),
+      ],
+      colorScheme: const ColorScheme(
+        brightness: Brightness.dark,
+        primary: _darkPrimary,
+        onPrimary: Color(0xFF111827),
+        secondary: _darkSecondary,
+        onSecondary: Color(0xFF111827),
+        tertiary: _darkTertiary,
+        onTertiary: Color(0xFF052E16),
+        error: Color(0xFFF87171),
+        onError: Color(0xFF1F2937),
+        surface: _darkSurface,
+        onSurface: Color(0xFFE2E8F0),
+        primaryContainer: Color(0xFF13476D),
+        onPrimaryContainer: Color(0xFFD8EEFF),
+        secondaryContainer: Color(0xFF2B2464),
+        onSecondaryContainer: Color(0xFFE6E7FF),
+        tertiaryContainer: Color(0xFF4A2A10),
+        onTertiaryContainer: Color(0xFFFFF0E4),
+        surfaceTint: _darkPrimary,
+        surfaceVariant: _darkSurfaceVariant,
+        onSurfaceVariant: Color(0xFFCBD5F5),
+        outline: Color(0xFF475569),
+        outlineVariant: Color(0xFF1E293B),
+        shadow: Color(0x66000000),
+        scrim: Color(0xAA000000),
+        inverseSurface: Color(0xFFF5F7FA),
+        onInverseSurface: Color(0xFF0F172A),
+        inversePrimary: _lightPrimary,
+      ),
+      scaffoldBackgroundColor: _darkSurface,
+      textTheme: baseTextTheme.apply(
+        bodyColor: const Color(0xFFE2E8F0),
+        displayColor: const Color(0xFFF8FAFC),
+      ),
+      cardTheme: CardTheme(
+        color: _darkSurfaceVariant,
+        surfaceTintColor: Colors.transparent,
+        shadowColor: _darkPrimary.withOpacity(0.32),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        margin: const EdgeInsets.all(16),
+        elevation: 8,
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: _darkSurfaceVariant,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: _darkNeutral),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: _darkNeutral),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: const BorderSide(color: _darkPrimary, width: 2),
+        ),
+        labelStyle: baseTextTheme.bodyMedium?.copyWith(
+          color: const Color(0xFFCBD5F5),
+        ),
+        hintStyle: baseTextTheme.bodyMedium?.copyWith(
+          color: const Color(0xFF94A3B8),
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: AppTheme.lightTheme.elevatedButtonTheme.style?.copyWith(
+              backgroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.disabled)) {
+                  return _darkPrimary.withOpacity(0.24);
+                }
+                return _darkSecondary;
+              }),
+              foregroundColor: WidgetStateProperty.resolveWith((states) {
+                if (states.contains(WidgetState.disabled)) {
+                  return const Color(0xFF475569);
+                }
+                return _darkSurface;
+              }),
+              overlayColor: WidgetStateProperty.all(
+                _darkSecondary.withOpacity(0.2),
+              ),
+              shadowColor: WidgetStateProperty.all(
+                _darkPrimary.withOpacity(0.28),
+              ),
+            ) ??
+            ButtonStyle(),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: AppTheme.lightTheme.outlinedButtonTheme.style?.copyWith(
+              foregroundColor: WidgetStateProperty.all(_darkPrimary),
+              side: WidgetStateProperty.all(
+                BorderSide(color: _darkPrimary.withOpacity(0.4)),
+              ),
+            ) ??
+            ButtonStyle(),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: AppTheme.lightTheme.textButtonTheme.style?.copyWith(
+              foregroundColor: WidgetStateProperty.all(_darkPrimary),
+            ) ??
+            ButtonStyle(),
+      ),
+      appBarTheme: AppBarTheme(
+        backgroundColor: _darkSurface,
+        surfaceTintColor: Colors.transparent,
+        foregroundColor: const Color(0xFFE2E8F0),
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        titleTextStyle: GoogleFonts.inter(
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+          color: const Color(0xFFF5F7FA),
+        ),
+      ),
+      bottomSheetTheme: BottomSheetThemeData(
+        backgroundColor: _darkSurfaceVariant,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        clipBehavior: Clip.antiAlias,
+        showDragHandle: true,
+      ),
+      navigationBarTheme: NavigationBarThemeData(
+        backgroundColor: _darkSurfaceVariant,
+        indicatorColor: _darkSecondary.withOpacity(0.24),
+        labelTextStyle: WidgetStateProperty.resolveWith(
+          (states) => baseTextTheme.labelMedium?.copyWith(
+            color: states.contains(WidgetState.selected)
+                ? _darkSecondary
+                : const Color(0xFFA8B1CF),
+          ),
+        ),
+        iconTheme: WidgetStateProperty.resolveWith(
+          (states) => IconThemeData(
+            color: states.contains(WidgetState.selected)
+                ? _darkSecondary
+                : const Color(0xFF94A3B8),
+          ),
+        ),
+      ),
+      chipTheme: ChipThemeData(
+        backgroundColor: _darkNeutral,
+        selectedColor: _darkSecondary.withOpacity(0.24),
+        secondarySelectedColor: _darkSecondary,
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        labelStyle: baseTextTheme.labelMedium!
+            .copyWith(color: const Color(0xFFE2E8F0)),
+        secondaryLabelStyle:
+            baseTextTheme.labelMedium!.copyWith(color: _darkSecondary),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        elevation: 0,
+        pressElevation: 0,
+      ),
+      dialogTheme: DialogTheme(
+        backgroundColor: _darkSurfaceVariant,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+        titleTextStyle: GoogleFonts.inter(
+          fontSize: 20,
+          fontWeight: FontWeight.w700,
+          color: Colors.white,
+        ),
+        contentTextStyle: GoogleFonts.inter(
+          fontSize: 14,
+          fontWeight: FontWeight.w400,
+          color: const Color(0xFFE2E8F0),
+        ),
+      ),
+      dividerTheme: const DividerThemeData(
+        thickness: 1,
+        space: 32,
+        color: Color(0xFF1F2937),
+      ),
+      pageTransitionsTheme: const PageTransitionsTheme(builders: {
+        TargetPlatform.android: FadeUpwardsPageTransitionsBuilder(),
+        TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+        TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
+        TargetPlatform.windows: FadeUpwardsPageTransitionsBuilder(),
+        TargetPlatform.linux: FadeUpwardsPageTransitionsBuilder(),
+      }),
+    );
+  }
+}
+
+class AppPalette extends ThemeExtension<AppPalette> {
+  const AppPalette({
+    required this.gradientStart,
+    required this.gradientEnd,
+    required this.neutralContainer,
+    required this.badgeBackground,
+    required this.badgeForeground,
+    required this.successEmphasis,
+    required this.warningEmphasis,
+  });
+
+  const AppPalette.light()
+      : gradientStart = AppTheme._lightGradientStart,
+        gradientEnd = AppTheme._lightGradientEnd,
+        neutralContainer = AppTheme._lightNeutral,
+        badgeBackground = AppTheme._lightSecondary,
+        badgeForeground = Colors.white,
+        successEmphasis = AppTheme._lightQuaternary,
+        warningEmphasis = const Color(0xFFFACC15);
+
+  const AppPalette.dark()
+      : gradientStart = AppTheme._darkGradientStart,
+        gradientEnd = AppTheme._darkGradientEnd,
+        neutralContainer = AppTheme._darkNeutral,
+        badgeBackground = AppTheme._darkSecondary,
+        badgeForeground = AppTheme._darkSurface,
+        successEmphasis = AppTheme._darkQuaternary,
+        warningEmphasis = const Color(0xFFEAB308);
+
+  final Color gradientStart;
+  final Color gradientEnd;
+  final Color neutralContainer;
+  final Color badgeBackground;
+  final Color badgeForeground;
+  final Color successEmphasis;
+  final Color warningEmphasis;
+
+  @override
+  AppPalette copyWith({
+    Color? gradientStart,
+    Color? gradientEnd,
+    Color? neutralContainer,
+    Color? badgeBackground,
+    Color? badgeForeground,
+    Color? successEmphasis,
+    Color? warningEmphasis,
+  }) {
+    return AppPalette(
+      gradientStart: gradientStart ?? this.gradientStart,
+      gradientEnd: gradientEnd ?? this.gradientEnd,
+      neutralContainer: neutralContainer ?? this.neutralContainer,
+      badgeBackground: badgeBackground ?? this.badgeBackground,
+      badgeForeground: badgeForeground ?? this.badgeForeground,
+      successEmphasis: successEmphasis ?? this.successEmphasis,
+      warningEmphasis: warningEmphasis ?? this.warningEmphasis,
+    );
+  }
+
+  @override
+  AppPalette lerp(ThemeExtension<AppPalette>? other, double t) {
+    if (other is! AppPalette) {
+      return this;
+    }
+
+    return AppPalette(
+      gradientStart: Color.lerp(gradientStart, other.gradientStart, t)!,
+      gradientEnd: Color.lerp(gradientEnd, other.gradientEnd, t)!,
+      neutralContainer:
+          Color.lerp(neutralContainer, other.neutralContainer, t)!,
+      badgeBackground:
+          Color.lerp(badgeBackground, other.badgeBackground, t)!,
+      badgeForeground:
+          Color.lerp(badgeForeground, other.badgeForeground, t)!,
+      successEmphasis:
+          Color.lerp(successEmphasis, other.successEmphasis, t)!,
+      warningEmphasis:
+          Color.lerp(warningEmphasis, other.warningEmphasis, t)!,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- refresh the light and dark `ThemeData` with a brighter cyan, violet, and amber palette plus gradient tokens via an `AppPalette` extension
- update FlutterFlow theme tokens to match the new palette so generated widgets inherit the refreshed colors
- modernize the sample `ModernOverviewCard` with the gradient accents and badge styling from the shared palette

## Testing
- `dart format lib/theme/app_theme.dart lib/components/modern_overview_card.dart lib/flutter_flow/flutter_flow_theme.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fcf41d00b8832b9ac8cdf508ae4f49